### PR TITLE
Fix a bug and add sorting to stl files

### DIFF
--- a/stl/__init__.py
+++ b/stl/__init__.py
@@ -54,7 +54,7 @@ def read_ascii_string(data):
     This is just a wrapper around :py:func:`read_ascii_file` that first wraps
     the provided string in a :py:class:`StringIO.StringIO` object.
     """
-    return parse_ascii_file(convert_to_stream(data))
+    return read_ascii_file(convert_to_stream(data))
 
 
 def read_binary_string(data):
@@ -65,4 +65,4 @@ def read_binary_string(data):
     This is just a wrapper around :py:func:`read_binary_file` that first wraps
     the provided string in a :py:class:`StringIO.StringIO` object.
     """
-    return parse_binary_file(convert_to_stream(data))
+    return read_binary_file(convert_to_stream(data))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import unittest
+import itertools
 from stl.types import *
 
 
@@ -48,3 +49,71 @@ class TestTypes(unittest.TestCase):
         )
 
         self.assertAlmostEqual(solid.surface_area, 0.5 + 0.5)
+
+    def test_vector3d_sort(self):
+        v1 = Vector3d(1, 2, 3)
+        v2 = Vector3d(4, 5, 6)
+        v3 = Vector3d(7, 8, 9)
+        for vertex_permutation in itertools.permutations([v1, v2, v3]):
+            self.assertEqual(sorted(vertex_permutation), [v1, v2, v3])
+
+    def test_facet_sort(self):
+        v1 = (1, 2, 3)
+        v2 = (4, 5, 6)
+        v3 = (7, 8, 9)
+
+        facet = Facet([0, 0, 0], [v1, v2, v3])
+        facet.sort_vertices()
+        self.assertEqual(facet, Facet([0, 0, 0], [v1, v2, v3]))
+
+        facet = Facet([0, 0, 0], [v3, v1, v2])
+        facet.sort_vertices()
+        self.assertEqual(facet, Facet([0, 0, 0], [v1, v2, v3]))
+
+        facet = Facet([0, 0, 0], [v3, v2, v1])
+        facet.sort_vertices()
+        self.assertEqual(facet, Facet([0, 0, 0], [v1, v3, v2]))
+
+    def test_solid_sort(self):
+        f0 = Facet(
+            (1, 0, 0),
+            [
+                (0, 0, 0),
+                (1, 0, 0),
+                (0, 0, 1),
+            ],
+        )
+        f0b = Facet(
+            (1, 0, 0),
+            [
+                (1, 0, 0),
+                (0, 0, 1),
+                (0, 0, 0),
+            ],
+        )
+        f1 = Facet(
+            (1, 0, 0),
+            [
+                (0, 0, 0),
+                (1, 0, 0),
+                (0, 1, 0),
+            ],
+        )
+
+        solid0 = Solid("test", [f0, f1])
+        solid0.sort_facets()
+        print (solid0)
+        expected_solid0 = Solid("test", [f0, f1])
+        self.assertEqual(solid0, expected_solid0)
+
+        solid1 = Solid("test", [f1, f0])
+        solid1.sort_facets()
+        print (solid1)
+        expected_solid1 = Solid("test", [f0, f1])
+        self.assertEqual(solid1, expected_solid1)
+
+        solid2 = Solid("test", [f1, f0b])
+        solid2.sort_facets()
+        print (solid2)
+        expected_solid2 = Solid("test", [f0, f1])
+        self.assertEqual(solid2, expected_solid2)


### PR DESCRIPTION
There is a bug in the code where it should say "read_binary..." and not "parse_binary..."

Also, I added sorting into the Solid type.  OpenScad output is not deterministic: the output can have facets in a different order each time.  This sort normalizes an STL file to a single order.
